### PR TITLE
Added a separate bulk_settings() for surface energy calculations

### DIFF
--- a/gaspy/defaults.py
+++ b/gaspy/defaults.py
@@ -91,6 +91,24 @@ def bulk_settings():
                                                  **xc_settings()))
     return bulk_settings
 
+def SE_bulk_settings():
+    ''' 
+    The default settings we use to do DFT calculations of bulks 
+    spefically for surface energy calculations. 
+    '''
+    SE_bulk_settings = OrderedDict(max_atoms=80,
+                                vasp=OrderedDict(ibrion=1,
+                                                 nsw=100,
+                                                 isif=7,
+                                                 isym=0,
+                                                 ediff=1e-8,
+                                                 kpts=(10, 10, 10),
+                                                 prec='Accurate',
+                                                 encut=500.,
+                                                 pp_version=pp_version(),
+                                                 **xc_settings('pbesol')))
+    return SE_bulk_settings
+
 
 def slab_settings():
     '''

--- a/gaspy/tasks/metadata_calculators.py
+++ b/gaspy/tasks/metadata_calculators.py
@@ -22,6 +22,7 @@ from .. import defaults
 GASDB_PATH = utils.read_rc('gasdb_path')
 GAS_SETTINGS = defaults.gas_settings()
 BULK_SETTINGS = defaults.bulk_settings()
+SE_BULK_SETTINGS = defaults.SE_bulk_settings()
 SLAB_SETTINGS = defaults.slab_settings()
 ADSLAB_SETTINGS = defaults.adslab_settings()
 
@@ -273,7 +274,7 @@ class CalculateSurfaceEnergy(luigi.Task):
     slab_generator_settings = luigi.DictParameter(SLAB_SETTINGS['slab_generator_settings'])
     get_slab_settings = luigi.DictParameter(SLAB_SETTINGS['get_slab_settings'])
     vasp_settings = luigi.DictParameter(SLAB_SETTINGS['vasp'])
-    bulk_vasp_settings = luigi.DictParameter(BULK_SETTINGS['vasp'])
+    bulk_vasp_settings = luigi.DictParameter(SE_BULK_SETTINGS['vasp'])
 
     def _static_requires(self):
         '''

--- a/gaspy/tests/tasks_tests/metadata_calculators_test.py
+++ b/gaspy/tests/tasks_tests/metadata_calculators_test.py
@@ -30,7 +30,7 @@ from ...tasks.core import schedule_tasks
 from ...tasks.calculation_finders import FindBulk, FindSurface
 
 GAS_SETTINGS = defaults.gas_settings()
-
+SE_BULK_SETTINGS = defaults.SE_bulk_settings()
 
 def test_CalculateAdsorptionEnergy():
     '''
@@ -150,7 +150,9 @@ class TestCalculateSurfaceEnergy():
         it and doesn't do some of the other steps (i.e., assign attributes)
         '''
         mpid = 'mp-1018129'
+        bulk_vasp_settings = SE_BULK_SETTINGS['vasp']
         task = CalculateSurfaceEnergy(mpid=mpid, miller_indices=(0, 0, 1), shift=0.081)
+        assert unfreeze_dict(task.bulk_vasp_settings) == bulk_vasp_settings
         bulk_task = task._static_requires()
         assert isinstance(bulk_task, FindBulk)
         assert bulk_task.mpid == mpid


### PR DESCRIPTION
The bulk relaxation needed for surface energy calculation should also use PBE solid (PBEsol) for vasp settings.  
3 files have been modified:
1. gaspy.defaults --> added a SE_bulk_settings() 
2. metadata_calculators --> the bulk vasp settings in CalculateSurfaceEnergy changed to defaults.SE_bulk_settings() (from the original defaults.bulk_settings()).
3. Testing Script for metadata_calculator is also modified.  