### PR TITLE
Avoid electronic logfiles

### DIFF
--- a/gaspy/defaults.py
+++ b/gaspy/defaults.py
@@ -163,7 +163,8 @@ def adslab_settings():
     (Angstroms) before we enumerate adsorption sites on it.
     '''
     adslab_settings = OrderedDict(min_xy=4.5,
-                                  rotation=OrderedDict(phi=0., theta=0., psi=0.),
+                                  rotation=OrderedDict(
+                                      phi=0., theta=0., psi=0.),
                                   vasp=OrderedDict(ibrion=2,
                                                    nsw=200,
                                                    isif=0,
@@ -220,7 +221,8 @@ def adsorbates():
     # Trying to apply Hookean so that CH bound doesn't dissociate. Actual structure
     # is H-C-O
     adsorbates['CHO'] = Atoms('CHO', positions=[[0., 0., 1.],
-                                                [-0.94, 0.2, 1.7],      # position of H
+                                                # position of H
+                                                [-0.94, 0.2, 1.7],
                                                 [0.986, 0.6, 1.8]])     # position of O
     adsorbates['CHO'].set_constraint([ase.constraints.Hookean(a1=0, a2=1, rt=1.59, k=5.),   # Bind CH, initially used k=7, lowered to 5
                                       ase.constraints.Hookean(a1=0, a2=2, rt=1.79, k=5.)])  # Bind CO
@@ -277,8 +279,10 @@ def adsorption_filters(adsorbate=None):
     # into harder-to-read (but mongo-readable) structures
     f_max = 0.5                 # Maximum atomic force [eV/Ang]
     ads_move_max = 1.5          # Maximum distance the adsorbate can move [Ang]
-    bare_slab_move_max = 0.5    # Maximum distance that any atom can move on bare slab [Ang]
-    slab_move_max = 1.5         # Maximum distance that any slab atom can move after adsorption [Ang]
+    # Maximum distance that any atom can move on bare slab [Ang]
+    bare_slab_move_max = 0.5
+    # Maximum distance that any slab atom can move after adsorption [Ang]
+    slab_move_max = 1.5
     if adsorbate == 'CO':
         energy_range = (-7., 5.)
     elif adsorbate == 'H':
@@ -306,10 +310,12 @@ def adsorption_filters(adsorbate=None):
                       UserWarning)
 
     # Distribute filters into mongo-readable form
-    filters['adsorption_energy'] = {'$gt': energy_range[0], '$lt': energy_range[1]}
+    filters['adsorption_energy'] = {
+        '$gt': energy_range[0], '$lt': energy_range[1]}
     filters['results.fmax'] = {'$lt': f_max}
     filters['movement_data.max_adsorbate_movement'] = {'$lt': ads_move_max}
-    filters['movement_data.max_bare_slab_movement'] = {'$lt': bare_slab_move_max}
+    filters['movement_data.max_bare_slab_movement'] = {
+        '$lt': bare_slab_move_max}
     filters['movement_data.max_slab_movement'] = {'$lt': slab_move_max}
     filters['vasp_settings.gga'] = xc_settings()['gga']
 

--- a/gaspy/defaults.py
+++ b/gaspy/defaults.py
@@ -16,6 +16,15 @@ def pp_version():
     return '5.4'
 
 
+def logfile_settings(keep_all_logfiles=False):
+    '''Whether to keep electronic log files (CHG, CHGCAR, WAVECAR)'''
+
+    logfile_settings = {'lwave': keep_all_logfiles,
+                        'lcharg': keep_all_logfiles}
+
+    return logfile_settings
+
+
 def xc_settings(xc='rpbe'):
     '''
     A dictionary whose keys are some typical sets of exchange correlationals
@@ -25,7 +34,7 @@ def xc_settings(xc='rpbe'):
     which we copied and put here.
     '''
     xc_settings = {'lda': OrderedDict(pp='LDA'),
-                    # GGAs
+                   # GGAs
                    'gga': OrderedDict(pp='GGA'),
                    'pbe': OrderedDict(pp='PBE'),
                    'revpbe': OrderedDict(pp='LDA', gga='RE'),
@@ -72,7 +81,8 @@ def gas_settings():
                                                 ediffg=-0.03,
                                                 encut=350.,
                                                 pp_version=pp_version(),
-                                                **xc_settings()))
+                                                **xc_settings(),
+                                                **logfile_settings()))
     return gas_settings
 
 
@@ -88,7 +98,8 @@ def bulk_settings():
                                                  prec='Accurate',
                                                  encut=500.,
                                                  pp_version=pp_version(),
-                                                 **xc_settings()))
+                                                 **xc_settings(),
+                                                 **logfile_settings()))
     return bulk_settings
 
 
@@ -107,7 +118,8 @@ def surface_energy_bulk_settings():
                                                     prec='Accurate',
                                                     encut=500.,
                                                     pp_version=pp_version(),
-                                                    **xc_settings('pbesol')))
+                                                    **xc_settings('pbesol'),
+                                                    **logfile_settings()))
     return SE_bulk_settings
 
 
@@ -129,7 +141,8 @@ def slab_settings():
                                                  ediffg=-0.03,
                                                  encut=350.,
                                                  pp_version=pp_version(),
-                                                 **xc_settings('pbesol')),
+                                                 **xc_settings('pbesol'),
+                                                 **logfile_settings()),
                                 slab_generator_settings=OrderedDict(min_slab_size=7.,
                                                                     min_vacuum_size=20.,
                                                                     lll_reduce=False,
@@ -161,7 +174,8 @@ def adslab_settings():
                                                    symprec=1e-10,
                                                    encut=350.,
                                                    pp_version=pp_version(),
-                                                   **xc_settings()))
+                                                   **xc_settings(),
+                                                   **logfile_settings()))
     return adslab_settings
 
 


### PR DESCRIPTION
To address #95.

This patch changes the default VASP settings to include `dict(lwave=False, lcharg=False)`, which avoids writing out the WAVECAR, CHGCAR, or CHG files at the end of a VASP execution, saving time during a Firework execution. Users who need these data files can change the default value of the argument for `gaspy.defaults.logfile_settings` to `True` or write a PyMongo interface to update the VASP settings within a Fireworks spec prior to runtime.

With these settings, WAVECAR, CHG, and CHGCAR files will still be written, but will be zero-length. `vasp_functions._delete_electronic_log_files` is left unchanged so that these files will still be cleared.