### PR TITLE
bulk_stability calculation unit test fixed

### DIFF
--- a/gaspy/gasdb.py
+++ b/gaspy/gasdb.py
@@ -12,7 +12,7 @@ from tqdm import tqdm
 from pymongo import MongoClient
 from pymongo.collection import Collection
 from pymatgen.ext.matproj import MPRester
-from pymatgen.analysis.pourbaix_diagram import PourbaixDiagram, ELEMENTS_HO, PourbaixPlotter
+from pymatgen.analysis.pourbaix_diagram import PourbaixDiagram, ELEMENTS_HO
 from . import defaults
 from .utils import read_rc
 from .fireworks_helper_scripts import get_launchpad
@@ -811,6 +811,7 @@ def purge_adslabs(fwids):
     print('Removing FWs from adsorption collection...')
     with get_mongo_collection('adsorption') as collection:
         collection.delete_many({'fwids.slab+adsorbate': {'$in': fwids}})
+
 
 def get_electrochemical_stability(mpid, pH, potential):
     '''

--- a/gaspy/tests/gasdb_test.py
+++ b/gaspy/tests/gasdb_test.py
@@ -511,8 +511,9 @@ def test_get_low_coverage_ml_docs(adsorbate, model_tag):
 
 def test_get_electrochemical_stability():
     # at pH=0, V=0.9
-    expected_stabilities = {'mp-126': 0.884,  # Pt
-                            'mp-81': 0.0}    # Au
+    expected_stabilities = {'mp-126': 0.861,  # Pt
+                            'mp-81': 0.0,     # Au
+                            'mp-2723': 0.0}   #IrO2
     for mpid, expected_stability in expected_stabilities.items():
         stability = get_electrochemical_stability(mpid, 0, 0.9)
         assert math.isclose(stability, expected_stability, rel_tol=1e-6)

--- a/gaspy/tests/gasdb_test.py
+++ b/gaspy/tests/gasdb_test.py
@@ -36,6 +36,7 @@ from ..gasdb import (get_mongo_collection,
                      get_electrochemical_stability)
 
 # Things we need to do the tests
+import math
 import pytest
 import warnings
 import copy
@@ -507,10 +508,11 @@ def test_get_low_coverage_ml_docs(adsorbate, model_tag):
         low_cov_energy = low_coverage_docs_by_surface[surface]['energy']
         assert low_cov_energy <= energy
 
+
 def test_get_electrochemical_stability():
     # at pH=0, V=0.9
-    expected_stabilities = {'mp-126':0.884,  # Pt
+    expected_stabilities = {'mp-126': 0.884,  # Pt
                             'mp-81': 0.0}    # Au
     for mpid, expected_stability in expected_stabilities.items():
         stability = get_electrochemical_stability(mpid, 0, 0.9)
-        assert stability == expected_stability
+        assert math.isclose(stability, expected_stability, rel_tol=1e-6)


### PR DESCRIPTION
PMG calculated the electrochemical stability of Pt-126 at pH=0, V=0.9 as 0.861eV/atom.  and I calculated that number differently a month ago (0.881eV/atom). I cannot figure out why anymore. So I updated the expected number, verified the 0.861 eV/atom is actually correct with the old PMG version (2018.9.1), as well as verified with the Pourbaix diagram on the MP website. In addition, I also added IrO2 bulk stability as a baseline for comparison. 