### PR TITLE
Update gaspy.vasp_functions for Python 3

### DIFF
--- a/gaspy/vasp_functions.py
+++ b/gaspy/vasp_functions.py
@@ -1,13 +1,14 @@
-'''
+"""
 This submodule is part of GASpy. It is meant to be used by FireWorks to perform
 VASP calculations.
-'''
+"""
 
-__authors__ = ['Zachary W. Ulissi', 'Kevin Tran']
-__emails__ = ['zulissi@andrew.cmu.edu', 'ktran@andrew.cmu.edu']
+__authors__ = ["Zachary W. Ulissi", "Kevin Tran"]
+__emails__ = ["zulissi@andrew.cmu.edu", "ktran@andrew.cmu.edu"]
 
 import os
 import uuid
+import binascii
 import numpy as np
 import ase.io
 from ase.io.trajectory import TrajectoryWriter
@@ -20,7 +21,7 @@ from ase.calculators.singlepoint import SinglePointCalculator as SPC
 
 
 def runVasp(fname_in, fname_out, vasp_flags):
-    '''
+    """
     This function is meant to be sent to each cluster and then used to run our
     rockets. As such, it has algorithms to run differently depending on the
     cluster that is trying to use this function.
@@ -38,7 +39,7 @@ def runVasp(fname_in, fname_out, vasp_flags):
                     trajectory
         energy      A float indicating the potential energy of the final image
                     in the relaxation [eV]
-    '''
+    """
     # Read the input atoms object
     atoms = ase.io.read(str(fname_in))
 
@@ -47,13 +48,14 @@ def runVasp(fname_in, fname_out, vasp_flags):
 
     # Parse and return output
     atoms_str = str(atoms)
-    traj_hex = open('all.traj', 'r').read().encode('hex')
+    with open('all.traj', 'rb') as fhandle:
+        traj_hex = binascii.hexlify(fhandle.read()).decode("utf-8")
     energy = final_image.get_potential_energy()
     return atoms_str, traj_hex, energy
 
 
 def _perform_relaxation(atoms, vasp_flags, fname_out):
-    '''
+    """
     This function will perform the DFT relaxation while also saving the final
     image for you.
 
@@ -65,16 +67,16 @@ def _perform_relaxation(atoms, vasp_flags, fname_out):
                     saving the final, relaxed structure
     Returns:
         atoms   The relaxed `ase.Atoms` structure
-    '''
+    """
     # Initialize some things before we run
     atoms, vasp_flags = _clean_up_vasp_inputs(atoms, vasp_flags)
     vasp_flags = _set_vasp_command(vasp_flags)
 
     # Detect whether or not there are constraints that cannot be handled by VASP
-    allowable_constraints = {'FixAtoms'}
+    allowable_constraints = {"FixAtoms"}
     vasp_compatible = True
     for constraint in atoms.constraints:
-        if constraint.todict()['name'] not in allowable_constraints:
+        if constraint.todict()["name"] not in allowable_constraints:
             vasp_compatible = False
             break
 
@@ -91,7 +93,7 @@ def _perform_relaxation(atoms, vasp_flags, fname_out):
 
 
 def _clean_up_vasp_inputs(atoms, vasp_flags):
-    '''
+    """
     There are some VASP settings that are used across all our clusters. This
     function takes care of these settings.
 
@@ -103,7 +105,7 @@ def _clean_up_vasp_inputs(atoms, vasp_flags):
         atoms       `ase.Atoms` object of the structure we want to relax, but
                     with the unit vectors fixed (if needed)
         vasp_flags  A modified version of the 'vasp_flags' argument
-    '''
+    """
     # Check that the unit vectors obey the right-hand rule, (X x Y points in
     # Z). If not, then flip the order of X and Y to enforce this so that VASP
     # is happy.
@@ -111,21 +113,23 @@ def _clean_up_vasp_inputs(atoms, vasp_flags):
         atoms.set_cell(atoms.cell[[1, 0, 2], :])
 
     # Set the pseudopotential type by setting 'xc' in Vasp()
-    if vasp_flags['pp'].lower() == 'lda':
-        vasp_flags['xc'] = 'lda'
-    elif vasp_flags['pp'].lower() == 'pbe':
-        vasp_flags['xc'] = 'PBE'
+    if vasp_flags["pp"].lower() == "lda":
+        vasp_flags["xc"] = "lda"
+    elif vasp_flags["pp"].lower() == "pbe":
+        vasp_flags["xc"] = "PBE"
 
     # Push the pseudopotentials into the OS environment for VASP to pull from
-    pseudopotential = vasp_flags['pp_version']
-    os.environ['VASP_PP_PATH'] = os.environ['VASP_PP_BASE'] + '/' + str(pseudopotential) + '/'
-    del vasp_flags['pp_version']
+    pseudopotential = vasp_flags["pp_version"]
+    os.environ["VASP_PP_PATH"] = (
+        os.environ["VASP_PP_BASE"] + "/" + str(pseudopotential) + "/"
+    )
+    del vasp_flags["pp_version"]
 
     return atoms, vasp_flags
 
 
 def _set_vasp_command(vasp_flags):
-    '''
+    """
     This function assigns the appropriate call to VASP to the `$VASP_COMMAND`
     variable. The command depends on what cluster we are running on. This
     function figures that out automatically.
@@ -135,34 +139,38 @@ def _set_vasp_command(vasp_flags):
                     calculator
     Returns:
         vasp_flags  A modified version of the 'vasp_flags' argument
-    '''
+    """
     # Figure out where we're running based on environment variables
-    if 'SLURM_CLUSTER_NAME' in os.environ:
-        cluster_name = os.environ['SLURM_CLUSTER_NAME']
-    elif 'PBS_O_HOST' in os.environ:
-        cluster_name = os.environ['PBS_O_HOST'].split()[0]
+    if "SLURM_CLUSTER_NAME" in os.environ:
+        cluster_name = os.environ["SLURM_CLUSTER_NAME"]
+    elif "PBS_O_HOST" in os.environ:
+        cluster_name = os.environ["PBS_O_HOST"].split()[0]
     else:
-        raise RuntimeError('Could not figure out what machine this job is '
-                           'running on and therefore could not figure out '
-                           'how to run VASP correctly. If you would like to '
-                           'add a subroutine for your cluster, please send a '
-                           'pull request to '
-                           'https://github.com/ulissigroup/GASpy')
+        raise RuntimeError(
+            "Could not figure out what machine this job is "
+            "running on and therefore could not figure out "
+            "how to run VASP correctly. If you would like to "
+            "add a subroutine for your cluster, please send a "
+            "pull request to "
+            "https://github.com/ulissigroup/GASpy"
+        )
 
     # Define which functions to use for which clusters
-    command_makers = {'cori': __make_cori_vasp_command,
-                      'arjuna': __make_arjuna_vasp_command,
-                      'gilgamesh': __make_gilgamesh_vasp_command}
+    command_makers = {
+        "cori": __make_cori_vasp_command,
+        "arjuna": __make_arjuna_vasp_command,
+        "gilgamesh": __make_gilgamesh_vasp_command,
+    }
 
     # Make the appropriate command to call VASP and then assign it to the
     # environment so that VASP can pick it up automatically.
     vasp_command, vasp_flags = command_makers[cluster_name](vasp_flags)
-    os.environ['VASP_COMMAND'] = vasp_command
+    os.environ["VASP_COMMAND"] = vasp_command
     return vasp_flags
 
 
 def __make_cori_vasp_command(vasp_flags):
-    '''
+    """
     Makes a VASP command to use on Cori
 
     Arg:
@@ -171,8 +179,8 @@ def __make_cori_vasp_command(vasp_flags):
     Returns:
         command     The command that should be executed in bash to run VASP
         vasp_flags  A modified version of the 'vasp_flags' argument
-    '''
-    vasp_executable = 'vasp_std'
+    """
+    vasp_executable = "vasp_std"
 
     # Figure out the number of processes
     try:
@@ -198,7 +206,7 @@ def __make_cori_vasp_command(vasp_flags):
 
 
 def __make_arjuna_vasp_command(vasp_flags):
-    '''
+    """
     Makes a VASP command to use on Arjuna
 
     Arg:
@@ -207,38 +215,38 @@ def __make_arjuna_vasp_command(vasp_flags):
     Returns:
         command     The command that should be executed in bash to run VASP
         vasp_flags  A modified version of the 'vasp_flags' argument
-    '''
+    """
     # Figure out the number of processes
     try:
-        n_processors = int(os.environ['SLURM_NPROCS'])
+        n_processors = int(os.environ["SLURM_NPROCS"])
     except KeyError:
         n_processors = 1
 
     # If this is a GPU job...
-    if os.environ['CUDA_VISIBLE_DEVICES'] != 'NoDevFiles':
-        vasp_flags['ncore'] = 1
-        vasp_flags['kpar'] = 16
-        vasp_flags['nsim'] = 8
-        vasp_flags['lreal'] = 'Auto'
-        vasp_executable = 'vasp_gpu'
-        command = 'mpirun -np %i %s' % (n_processors, vasp_executable)
+    if os.environ["CUDA_VISIBLE_DEVICES"] != "NoDevFiles":
+        vasp_flags["ncore"] = 1
+        vasp_flags["kpar"] = 16
+        vasp_flags["nsim"] = 8
+        vasp_flags["lreal"] = "Auto"
+        vasp_executable = "vasp_gpu"
+        command = "mpirun -np %i %s" % (n_processors, vasp_executable)
 
     # If this is a CPU job...
     else:
-        vasp_executable = 'vasp_std'
+        vasp_executable = "vasp_std"
         if n_processors > 16:
-            vasp_flags['ncore'] = 4
-            vasp_flags['kpar'] = 4
+            vasp_flags["ncore"] = 4
+            vasp_flags["kpar"] = 4
         else:
-            vasp_flags['kpar'] = 1
-            vasp_flags['ncore'] = 4
-        command = 'mpirun -np %i %s' % (n_processors, vasp_executable)
+            vasp_flags["kpar"] = 1
+            vasp_flags["ncore"] = 4
+        command = "mpirun -np %i %s" % (n_processors, vasp_executable)
 
     return command, vasp_flags
 
 
 def __make_gilgamesh_vasp_command(vasp_flags):
-    '''
+    """
     Makes a VASP command to use on Gilgamesh
 
     Arg:
@@ -247,17 +255,19 @@ def __make_gilgamesh_vasp_command(vasp_flags):
     Returns:
         command     The command that should be executed in bash to run VASP
         vasp_flags  A modified version of the 'vasp_flags' argument
-    '''
-    os.environ['PBS_SERVER'] = 'gilgamesh.cheme.cmu.edu'
-    vasp_flags['npar'] = 4
-    vasp_executable = '/home-research/zhongnanxu/opt/vasp-5.3.5/bin/vasp-vtst-beef-parallel'
-    n_processors = len(open(os.environ['PBS_NODEFILE']).readlines())
-    command = 'mpirun -np %i %s' % (n_processors, vasp_executable)
+    """
+    os.environ["PBS_SERVER"] = "gilgamesh.cheme.cmu.edu"
+    vasp_flags["npar"] = 4
+    vasp_executable = (
+        "/home-research/zhongnanxu/opt/vasp-5.3.5/bin/vasp-vtst-beef-parallel"
+    )
+    n_processors = len(open(os.environ["PBS_NODEFILE"]).readlines())
+    command = "mpirun -np %i %s" % (n_processors, vasp_executable)
     return command, vasp_flags
 
 
 def _relax_with_ase(atoms, vasp_flags):
-    '''
+    """
     Instead of letting VASP handle the relaxation autonomously, we instead use
     VASP only as an eletronic structure calculator and use ASE's BFGS to
     perform the atomic position optimization.
@@ -271,18 +281,18 @@ def _relax_with_ase(atoms, vasp_flags):
                     calculator
     Returns:
         atoms   The relaxed `ase.Atoms` structure
-    '''
-    vasp_flags['ibrion'] = 2
-    vasp_flags['nsw'] = 0
+    """
+    vasp_flags["ibrion"] = 2
+    vasp_flags["nsw"] = 0
     calc = Vasp2(**vasp_flags)
     atoms.set_calculator(calc)
-    optimizer = BFGS(atoms, logfile='relax.log', trajectory='all.traj')
-    optimizer.run(fmax=vasp_flags['ediffg'] if 'ediffg' in vasp_flags else 0.05)
+    optimizer = BFGS(atoms, logfile="relax.log", trajectory="all.traj")
+    optimizer.run(fmax=vasp_flags["ediffg"] if "ediffg" in vasp_flags else 0.05)
     return atoms
 
 
 def _relax_with_vasp(atoms, vasp_flags):
-    '''
+    """
     Perform a DFT relaxation with VASP and then write the trajectory to the
     'all.traj' file and save the log file.
 
@@ -292,7 +302,7 @@ def _relax_with_vasp(atoms, vasp_flags):
                     calculator
     Returns:
         atoms   The relaxed `ase.Atoms` structure
-    '''
+    """
     # Run the calculation
     calc = Vasp2(**vasp_flags)
     atoms.set_calculator(calc)
@@ -300,43 +310,54 @@ def _relax_with_vasp(atoms, vasp_flags):
 
     # Read the trajectory from the output file
     images = []
-    for atoms in ase.io.read('vasprun.xml', ':'):
+    for atoms in ase.io.read("vasprun.xml", ":"):
         image = atoms.copy()
         image = image[calc.resort]
-        image.set_calculator(SPC(image,
-                                 energy=atoms.get_potential_energy(),
-                                 forces=atoms.get_forces()[calc.resort]))
+        image.set_calculator(
+            SPC(
+                image,
+                energy=atoms.get_potential_energy(),
+                forces=atoms.get_forces()[calc.resort],
+            )
+        )
         images += [image]
 
     # Write the trajectory
-    with TrajectoryWriter('all.traj', 'a') as tj:
+    with TrajectoryWriter("all.traj", "a") as tj:
         for atoms in images:
             tj.write(atoms)
     return images[-1]
 
 
 def atoms_to_hex(atoms):
-    '''
+    """
     Turn an atoms object into a hex string so that we can pass it through fireworks
 
     Arg:
         atoms   The `ase.Atoms` object that you want to hex encode
     Returns:
         _hex    A hex string of the `ase.Atoms` object
-    '''
+    """
     # We need to write the atoms object into a file before encoding it. But we don't
     # want multiple calls to this function to interfere with each other, so we generate
     # a random file name via uuid to reduce this risk. Then we delete it.
-    fname = str(uuid.uuid4()) + '.traj'
+    fname = str(uuid.uuid4()) + ".traj"
     atoms.write(fname)
-    with open(fname) as fhandle:
-        _hex = fhandle.read().encode('hex')
-        os.remove(fname)
+    with open(fname, "rb") as fhandle:
+        try:
+            _hex = binascii.hexlify(fhandle.read()).decode("utf-8")
+            os.remove(fname)
+        except OSError:
+            pass
+
     return _hex
 
 
+#decode_hex = codecs.getdecoder("hex_codec")
+
+
 def hex_to_file(file_name, hex_):
-    '''
+    """
     Write a hex string into a file. One application is to unpack hexed atoms
     pobjects in local fireworks job directories
 
@@ -344,7 +365,9 @@ def hex_to_file(file_name, hex_):
         file_name   A string indicating the name of the file you want to write
                     to
         hex_        A hex string of the object you want to write to the file
-    '''
-    # Dump the hex encoded string to a local file
-    with open(file_name, 'w') as fhandle:
-        fhandle.write(hex_.decode('hex'))
+    """
+    with open(file_name, 'wb') as fhandle:
+        unhex_str = binascii.unhexlify(hex_)
+        # b = str(unhex_str)[2:-1]
+        # b1 = bytes(b, 'utf-8')
+        fhandle.write(unhex_str)


### PR DESCRIPTION
Our GASpy installation uses the Conda environment defined in `dockerfile/Dockerfile` to manage all calculation scheduling, the Luigi server, Fireworks, and the `gaspy.vasp_functions` module copied to each Fireworks launch folder. Here are the basic changes we've made to make `gaspy.vasp_functions` compatible with the Python 3-based Docker environment.

At one point, we formatted `gaspy.vasp_functions` with [black](https://black.readthedocs.io/en/stable/), which introduced a lot of changes by converting single quotes to double quotes. I didn't want to undo this and risk giving you a non-working version without further testing, but am happy to do this if it would make your diffs cleaner.

### Better detect cluster environment on Cori and use KNL nodes more fully

Updates to Slurm deprecated some of the environment variables used to determine the number of logical CPUs available on each node. In particular, the `SLURM_NPROCS` variable no longer exists as of 20 Jul 2020 (probably because of the recent upgrade to Slurm 20.02.3). It is replaced in the Cori subroutine with `SLURM_CPUS_ON_NODE`. (Unless you are using the Haswell shared QOS, this can be interchanged with `SLURM_JOB_CPUS_PER_NODE`.) Slurm sees each hardware hyperthread as a logical CPU, so Haswell nodes will have 64 Slurm CPUs. Any job detected to have more than 64 Slurm CPUs allocated will use the KNL code.

The `srun` command for KNL nodes was underutilizing the number of available hardware hyperthreads, leading to some job timeouts. We felt that OpenMP rule of thumb in the [NERSC docs](https://docs.nersc.gov/jobs/examples/#hybrid-mpiopenmp-jobs) (1 OpenMP task per physical core) was a good idea, so we modified the code to use 68 MPI tasks at 4 hyperthreads per task. But please let us know if you find a more efficient way to run tasks!

Some unit cell optimizations were timing out, and benchmarking revealed that increasing the VASP INCAR tag `ncore` to `NCORE=16` could save time. This is done any time any dimension of the *k* point mesh is greater than 5.

I made no changes to the Arjuna or Gilgamesh subroutines because I don't know anything about those clusters.

### Fix hex serialization/deserialization for Python 3

Apparently Python 2 had hex codecs accessible from the `str.encode` and `bytes.decode` methods. This appears to not be the case with Python 3, but the standard `binascii` library makes it quite easy to to the encoding. We've patched all hex serialization/deserialization routines with `binascii`. This conceptually could be done for `gaspy.fireworks_helper_scripts`, but we have not noticed any hex failures during regular use of this module.

Hope this helps!
-- Sam